### PR TITLE
feat: add Prometheus metrics to tracker

### DIFF
--- a/internal/scraper/collector.go
+++ b/internal/scraper/collector.go
@@ -68,6 +68,7 @@ func (c *Collector) run() {
 		c.Log.Debug("Scrape success",
 			zap.String("target", res.Target),
 			zap.Int("num_snapshots", len(res.Infos)))
+		snapshotsFound.WithLabelValues(res.Group).Add(float64(len(res.Infos)))
 		c.DB.DeleteSnapshotsByTarget(res.Group, res.Target)
 		entries := make([]*index.SnapshotEntry, len(res.Infos))
 		for i, info := range res.Infos {

--- a/internal/scraper/metrics.go
+++ b/internal/scraper/metrics.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Blockdaemon Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scraper
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// targetsDiscovered tracks the current number of targets found per group
+	// via Consul service discovery on each scrape cycle.
+	targetsDiscovered = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "solana_cluster_tracker_targets_total",
+			Help: "Current number of targets discovered via service discovery.",
+		},
+		[]string{"group"},
+	)
+
+	// snapshotsFound counts the total number of snapshots found across all
+	// targets per group over time.
+	snapshotsFound = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "solana_cluster_tracker_snapshots_found_total",
+			Help: "Total number of snapshots found across all targets.",
+		},
+		[]string{"group"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(targetsDiscovered, snapshotsFound)
+}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -83,6 +83,8 @@ func (s *Scraper) scrape(ctx context.Context, results chan<- ProbeResult) {
 		return
 	}
 
+	targetsDiscovered.WithLabelValues(s.prober.group).Set(float64(len(targets)))
+
 	scrapeStart := time.Now()
 	s.Log.Debug("Scrape starting",
 		zap.Duration("discovery_duration", time.Since(discoveryStart)),

--- a/internal/tracker/metrics.go
+++ b/internal/tracker/metrics.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Blockdaemon Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracker
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// snapshotAge tracks how old the best available snapshot is, measured in slots
+// relative to the current slot fetched from RPC. Updated on each health check.
+var snapshotAge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "solana_cluster_tracker_snapshot_age_slots",
+		Help: "Age of the best available snapshot in slots relative to current RPC slot.",
+	},
+	[]string{"group"},
+)
+
+func init() {
+	prometheus.MustRegister(snapshotAge)
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -138,6 +138,14 @@ func (h *Handler) Health(c *gin.Context) {
 		}
 		health.CurrentSlot = out
 
+		group := query.Group
+		if group == "" {
+			group = entries[0].Group
+		}
+		if health.CurrentSlot >= health.MaxSnapshot {
+			snapshotAge.WithLabelValues(group).Set(float64(health.CurrentSlot - health.MaxSnapshot))
+		}
+
 		if (health.CurrentSlot - health.MaxSnapshot) > h.MaxSnapshotAge {
 			health.Health = "snapshot too old"
 			c.JSON(http.StatusServiceUnavailable, health)


### PR DESCRIPTION
Expose three metrics on the /metrics endpoint (internal server):
- solana_cluster_tracker_targets_total (gauge, label: group): current number of targets discovered via Consul service discovery each scrape cycle
- solana_cluster_tracker_snapshots_found_total (counter, label: group): total snapshots collected from all targets over time
- solana_cluster_tracker_snapshot_age_slots (gauge, label: group): age of best available snapshot in slots relative to current RPC slot, updated on each health check call