### PR TITLE
feat(ACC-246): Add HTTP snapshot targets

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -27,13 +27,11 @@ target_groups:
     # file_targets:
     #   path: <filename>
 
-    # Discover targets from a HTTP server.
+    # Discover targets from URLs exposing /snapshot.tar.bz2 redirects.
     #
     # http_targets:
-    #   url: <string>
-    #   basic_auth: <...>
-    #   bearer_auth: <...>
-    #   tls_config: <...>
+    #   targets:
+    #     - https://api.mainnet.solana.com
 
     # ------------------------------------------------
     # Authentication

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -40,5 +40,8 @@ func NewFromConfig(t *types.TargetGroup) (Discoverer, error) {
 	if t.ConsulSDConfig != nil {
 		return NewConsulFromConfig(t.ConsulSDConfig)
 	}
+	if t.HttpTargets != nil {
+		return t.HttpTargets, nil
+	}
 	return nil, fmt.Errorf("missing config")
 }

--- a/internal/integrationtest/tracker_test.go
+++ b/internal/integrationtest/tracker_test.go
@@ -97,6 +97,9 @@ func TestTracker(t *testing.T) {
 		for _, file := range snap.Files {
 			assert.NotNil(t, file.ModTime)
 			file.ModTime = nil
+			assert.NotEmpty(t, file.DownloadURL)
+			assert.Contains(t, file.DownloadURL, "/v1/snapshot/"+file.FileName)
+			file.DownloadURL = ""
 		}
 		assert.NotEmpty(t, snap.Target)
 		snap.Target = ""

--- a/internal/scraper/prober.go
+++ b/internal/scraper/prober.go
@@ -17,12 +17,15 @@ package scraper
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 
 	"go.blockdaemon.com/solana/cluster-manager/internal/fetch"
+	"go.blockdaemon.com/solana/cluster-manager/internal/ledger"
 	"go.blockdaemon.com/solana/cluster-manager/types"
 )
 
@@ -33,6 +36,7 @@ type Prober struct {
 	scheme  string
 	apiPath string
 	header  http.Header
+	urlMode bool
 }
 
 func NewProber(group *types.TargetGroup) (*Prober, error) {
@@ -70,9 +74,6 @@ func NewProber(group *types.TargetGroup) (*Prober, error) {
 		},
 		Timeout: 10 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) == 1 {
-				return nil
-			}
 			return http.ErrUseLastResponse
 		},
 	}
@@ -83,15 +84,112 @@ func NewProber(group *types.TargetGroup) (*Prober, error) {
 		scheme:  group.Scheme,
 		apiPath: group.APIPath,
 		header:  header,
+		urlMode: group.HttpTargets != nil,
 	}, nil
 }
 
 // Probe fetches the snapshots of a single target.
 func (p *Prober) Probe(ctx context.Context, target string) ([]*types.SnapshotInfo, error) {
+	if p.urlMode {
+		return p.probeURL(ctx, target)
+	}
+
 	u := url.URL{
 		Scheme: p.scheme,
 		Host:   target,
 		Path:   p.apiPath,
 	}
 	return fetch.NewSidecarClient(u.String()).ListSnapshots(ctx)
+}
+
+func (p *Prober) ProbeTarget(target string) string {
+	if p.urlMode {
+		return target
+	}
+	return p.scheme + "://" + target
+}
+
+func (p *Prober) probeURL(ctx context.Context, target string) ([]*types.SnapshotInfo, error) {
+	full, err := p.headSnapshot(ctx, target, "snapshot.tar.bz2")
+	if err != nil {
+		return nil, err
+	}
+	incremental, err := p.headSnapshot(ctx, target, "incremental-snapshot.tar.bz2")
+	if err != nil {
+		return nil, err
+	}
+
+	infos := make([]*types.SnapshotInfo, 0, 2)
+	if full != nil {
+		infos = append(infos, &types.SnapshotInfo{
+			Slot:      full.Slot,
+			BaseSlot:  full.Slot,
+			Hash:      full.Hash,
+			Files:     []*types.SnapshotFile{full},
+			TotalSize: full.Size,
+		})
+	}
+	if incremental != nil {
+		files := []*types.SnapshotFile{incremental}
+		totalSize := incremental.Size
+		if full != nil && incremental.BaseSlot == full.Slot {
+			files = append(files, full)
+			totalSize += full.Size
+		}
+		infos = append(infos, &types.SnapshotInfo{
+			Slot:      incremental.Slot,
+			BaseSlot:  incremental.BaseSlot,
+			Hash:      incremental.Hash,
+			Files:     files,
+			TotalSize: totalSize,
+		})
+	}
+	return infos, nil
+}
+
+func (p *Prober) headSnapshot(ctx context.Context, target string, name string) (*types.SnapshotFile, error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("parse target URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("target must be an absolute URL: %q", target)
+	}
+	u.Path = path.Join(u.Path, name)
+	u.RawPath = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = p.header.Clone()
+
+	res, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusAccepted {
+		return nil, nil
+	}
+	if res.StatusCode < 300 || res.StatusCode >= 400 {
+		return nil, fmt.Errorf("head %s: %s", u.String(), res.Status)
+	}
+
+	location := res.Header.Get("Location")
+	if location == "" {
+		return nil, fmt.Errorf("head %s: missing Location header", u.String())
+	}
+
+	locationURL, err := u.Parse(location)
+	if err != nil {
+		return nil, fmt.Errorf("parse Location header: %w", err)
+	}
+	file := ledger.ParseSnapshotFileName(path.Base(locationURL.Path))
+	if file == nil {
+		return nil, fmt.Errorf("parse snapshot filename from Location header: %q", location)
+	}
+	file.FileName = locationURL.String()
+	return file, nil
 }

--- a/internal/scraper/prober.go
+++ b/internal/scraper/prober.go
@@ -99,7 +99,19 @@ func (p *Prober) Probe(ctx context.Context, target string) ([]*types.SnapshotInf
 		Host:   target,
 		Path:   p.apiPath,
 	}
-	return fetch.NewSidecarClient(u.String()).ListSnapshots(ctx)
+	infos, err := fetch.NewSidecarClient(u.String()).ListSnapshots(ctx)
+	if err != nil {
+		return nil, err
+	}
+	baseURL := u.String()
+	for _, info := range infos {
+		for _, file := range info.Files {
+			if file.DownloadURL == "" {
+				file.DownloadURL = baseURL + "/v1/snapshot/" + url.PathEscape(file.FileName)
+			}
+		}
+	}
+	return infos, nil
 }
 
 func (p *Prober) ProbeTarget(target string) string {
@@ -190,6 +202,6 @@ func (p *Prober) headSnapshot(ctx context.Context, target string, name string) (
 	if file == nil {
 		return nil, fmt.Errorf("parse snapshot filename from Location header: %q", location)
 	}
-	file.FileName = locationURL.String()
+	file.DownloadURL = locationURL.String()
 	return file, nil
 }

--- a/internal/scraper/prober_test.go
+++ b/internal/scraper/prober_test.go
@@ -1,0 +1,68 @@
+package scraper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.blockdaemon.com/solana/cluster-manager/types"
+)
+
+func TestProber_ProbeURL(t *testing.T) {
+	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodHead, r.Method)
+
+		switch r.URL.Path {
+		case "/snapshot.tar.bz2":
+			w.Header().Set("Location", "/snapshot-100-"+hash+".tar.zst")
+			w.WriteHeader(http.StatusSeeOther)
+		case "/incremental-snapshot.tar.bz2":
+			w.Header().Set("Location", "/incremental-snapshot-100-200-"+hash+".tar.zst")
+			w.WriteHeader(http.StatusSeeOther)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	prober, err := NewProber(&types.TargetGroup{
+		Group:       "mainnet",
+		HttpTargets: &types.HttpTargets{},
+	})
+	require.NoError(t, err)
+
+	infos, err := prober.Probe(context.Background(), server.URL)
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+
+	assert.Equal(t, uint64(100), infos[0].Slot)
+	assert.Equal(t, uint64(100), infos[0].BaseSlot)
+	require.Len(t, infos[0].Files, 1)
+	assert.Equal(t, server.URL+"/snapshot-100-"+hash+".tar.zst", infos[0].Files[0].FileName)
+
+	assert.Equal(t, uint64(200), infos[1].Slot)
+	assert.Equal(t, uint64(100), infos[1].BaseSlot)
+	require.Len(t, infos[1].Files, 2)
+	assert.Equal(t, server.URL+"/incremental-snapshot-100-200-"+hash+".tar.zst", infos[1].Files[0].FileName)
+	assert.Equal(t, server.URL+"/snapshot-100-"+hash+".tar.zst", infos[1].Files[1].FileName)
+}
+
+func TestProber_ProbeURLNoSnapshot(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	prober, err := NewProber(&types.TargetGroup{
+		Group:       "mainnet",
+		HttpTargets: &types.HttpTargets{},
+	})
+	require.NoError(t, err)
+
+	infos, err := prober.Probe(context.Background(), server.URL)
+	require.NoError(t, err)
+	assert.Empty(t, infos)
+}

--- a/internal/scraper/prober_test.go
+++ b/internal/scraper/prober_test.go
@@ -43,13 +43,16 @@ func TestProber_ProbeURL(t *testing.T) {
 	assert.Equal(t, uint64(100), infos[0].Slot)
 	assert.Equal(t, uint64(100), infos[0].BaseSlot)
 	require.Len(t, infos[0].Files, 1)
-	assert.Equal(t, server.URL+"/snapshot-100-"+hash+".tar.zst", infos[0].Files[0].FileName)
+	assert.Equal(t, "snapshot-100-"+hash+".tar.zst", infos[0].Files[0].FileName)
+	assert.Equal(t, server.URL+"/snapshot-100-"+hash+".tar.zst", infos[0].Files[0].DownloadURL)
 
 	assert.Equal(t, uint64(200), infos[1].Slot)
 	assert.Equal(t, uint64(100), infos[1].BaseSlot)
 	require.Len(t, infos[1].Files, 2)
-	assert.Equal(t, server.URL+"/incremental-snapshot-100-200-"+hash+".tar.zst", infos[1].Files[0].FileName)
-	assert.Equal(t, server.URL+"/snapshot-100-"+hash+".tar.zst", infos[1].Files[1].FileName)
+	assert.Equal(t, "incremental-snapshot-100-200-"+hash+".tar.zst", infos[1].Files[0].FileName)
+	assert.Equal(t, server.URL+"/incremental-snapshot-100-200-"+hash+".tar.zst", infos[1].Files[0].DownloadURL)
+	assert.Equal(t, "snapshot-100-"+hash+".tar.zst", infos[1].Files[1].FileName)
+	assert.Equal(t, server.URL+"/snapshot-100-"+hash+".tar.zst", infos[1].Files[1].DownloadURL)
 }
 
 func TestProber_ProbeURLNoSnapshot(t *testing.T) {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -99,7 +99,7 @@ func (s *Scraper) scrape(ctx context.Context, results chan<- ProbeResult) {
 			results <- ProbeResult{
 				Group:  s.prober.group,
 				Time:   time.Now(),
-				Target: s.prober.scheme + "://" + target,
+				Target: s.prober.ProbeTarget(target),
 				Infos:  infos,
 				Err:    err,
 			}

--- a/test-http-target-config.yml
+++ b/test-http-target-config.yml
@@ -1,0 +1,7 @@
+scrape_interval: 30s
+
+target_groups:
+  - group: mainnet
+    http_targets:
+      targets:
+        - https://api.mainnet.solana.com

--- a/types/config.go
+++ b/types/config.go
@@ -57,6 +57,7 @@ type TargetGroup struct {
 	StaticTargets  *StaticTargets  `json:"static_targets" yaml:"static_targets"`
 	FileTargets    *FileTargets    `json:"file_targets" yaml:"file_targets"`
 	ConsulSDConfig *ConsulSDConfig `json:"consul_sd_config" yaml:"consul_sd_config"`
+	HttpTargets    *HttpTargets    `json:"http_targets" yaml:"http_targets"`
 }
 
 // StaticTargets is a hardcoded list of Solana nodes.
@@ -87,6 +88,15 @@ func (d *FileTargets) DiscoverTargets(_ context.Context) ([]string, error) {
 	}
 
 	return lines, scn.Err()
+}
+
+// HttpTargets is a hardcoded list of Solana snapshot URLs.
+type HttpTargets struct {
+	Targets []string `json:"targets" yaml:"targets"`
+}
+
+func (h *HttpTargets) DiscoverTargets(_ context.Context) ([]string, error) {
+	return h.Targets, nil
 }
 
 // ConsulSDConfig configures Consul service discovery.

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -36,4 +37,25 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, actual)
+}
+
+func TestLoadConfigHttpTargets(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yml")
+	err := os.WriteFile(configFile, []byte(`
+scrape_interval: 15s
+target_groups:
+  - group: mainnet
+    http_targets:
+      targets:
+        - https://api.mainnet.solana.com
+`), 0o600)
+	require.NoError(t, err)
+
+	actual, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	require.Len(t, actual.TargetGroups, 1)
+	assert.Equal(t, &HttpTargets{
+		Targets: []string{"https://api.mainnet.solana.com"},
+	}, actual.TargetGroups[0].HttpTargets)
 }

--- a/types/snapshot.go
+++ b/types/snapshot.go
@@ -40,11 +40,12 @@ type SnapshotInfo struct {
 
 // SnapshotFile is a file that makes up a snapshot (either full or incremental).
 type SnapshotFile struct {
-	FileName string      `json:"file_name"`
-	Slot     uint64      `json:"slot"`
-	BaseSlot uint64      `json:"base_slot,omitempty"`
-	Hash     solana.Hash `json:"hash"`
-	Ext      string      `json:"ext"`
+	FileName    string      `json:"file_name"`
+	DownloadURL string      `json:"download_url,omitempty"`
+	Slot        uint64      `json:"slot"`
+	BaseSlot    uint64      `json:"base_slot,omitempty"`
+	Hash        solana.Hash `json:"hash"`
+	Ext         string      `json:"ext"`
 
 	ModTime *time.Time `json:"mod_time,omitempty"`
 	Size    uint64     `json:"size,omitempty"`


### PR DESCRIPTION
## Summary
- add http_targets config support for public snapshot redirect URLs
- discover full and incremental snapshots via HEAD requests to /snapshot.tar.bz2 and /incremental-snapshot.tar.bz2
- store resolved Location URLs in snapshot metadata and add focused tests plus a live test config

## Testing
- go test ./...
- built /tmp/solana-snapshots and verified /v1/best_snapshots returns snapshots using test-http-target-config.yml