### PR TITLE
Add snapshot redirect and proxy endpoints

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -1,5 +1,9 @@
 scrape_interval: 15s
 
+# Proxy concrete snapshot downloads through the tracker instead of redirecting
+# clients to sidecars or HTTP snapshot targets directly.
+proxy_snapshot_downloads: false
+
 target_groups:
   # A group of nodes on the same Solana network.
   - group: mainnet

--- a/example-config.yml
+++ b/example-config.yml
@@ -4,6 +4,10 @@ scrape_interval: 15s
 # clients to sidecars or HTTP snapshot targets directly.
 proxy_snapshot_downloads: false
 
+# Optional local cache for proxied concrete snapshot downloads. When enabled,
+# only the latest requested snapshot archive is kept.
+proxy_snapshot_cache_dir: ""
+
 target_groups:
   # A group of nodes on the same Solana network.
   - group: mainnet

--- a/internal/cmd/tracker/tracker.go
+++ b/internal/cmd/tracker/tracker.go
@@ -96,6 +96,12 @@ func run() {
 		},
 	))
 
+	// Create config reloader.
+	config, err := types.LoadConfig(configPath)
+	if err != nil {
+		log.Fatal("Failed to load config", zap.Error(err))
+	}
+
 	// Create result collector.
 	db := index.NewDB()
 	collector := scraper.NewCollector(db)
@@ -110,6 +116,7 @@ func run() {
 	server.Use(ginzap.RecoveryWithZap(httpLog, false))
 
 	handler := tracker.NewHandler(db, rpc, maxSnapshotAge)
+	handler.ProxySnapshotDownloads = config.ProxySnapshotDownloads
 	handler.RegisterHandlers(server.Group("/v1"))
 
 	// Start services.
@@ -120,12 +127,6 @@ func run() {
 	runGroupServer(ctx, group, internalListen, nil) // default handler
 	httpLog.Info("Starting server", zap.String("listen", listen))
 	runGroupServer(ctx, group, listen, server) // public handler
-
-	// Create config reloader.
-	config, err := types.LoadConfig(configPath)
-	if err != nil {
-		log.Fatal("Failed to load config", zap.Error(err))
-	}
 
 	// Create scrape managers.
 	manager := scraper.NewManager(collector.Probes())

--- a/internal/cmd/tracker/tracker.go
+++ b/internal/cmd/tracker/tracker.go
@@ -117,6 +117,7 @@ func run() {
 
 	handler := tracker.NewHandler(db, rpc, maxSnapshotAge)
 	handler.ProxySnapshotDownloads = config.ProxySnapshotDownloads
+	handler.ProxySnapshotCacheDir = config.ProxySnapshotCacheDir
 	handler.RegisterHandlers(server.Group("/v1"))
 
 	// Start services.

--- a/internal/sidecar/snapshot.go
+++ b/internal/sidecar/snapshot.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/gin-gonic/gin"
 	"go.blockdaemon.com/solana/cluster-manager/internal/ledger"
@@ -49,8 +50,14 @@ func (s *SnapshotHandler) RegisterHandlers(group gin.IRoutes) {
 	group.GET("/snapshot.tar.bz2", s.DownloadBestSnapshot)
 	group.HEAD("/snapshot.tar.zst", s.DownloadBestSnapshot)
 	group.GET("/snapshot.tar.zst", s.DownloadBestSnapshot)
+	group.HEAD("/incremental-snapshot.tar.bz2", s.DownloadBestIncrementalSnapshot)
+	group.GET("/incremental-snapshot.tar.bz2", s.DownloadBestIncrementalSnapshot)
+	group.HEAD("/incremental-snapshot.tar.zst", s.DownloadBestIncrementalSnapshot)
+	group.GET("/incremental-snapshot.tar.zst", s.DownloadBestIncrementalSnapshot)
 	group.HEAD("/snapshot/:name", s.DownloadSnapshot)
 	group.GET("/snapshot/:name", s.DownloadSnapshot)
+	group.HEAD("/:name", s.DownloadSnapshot)
+	group.GET("/:name", s.DownloadSnapshot)
 }
 
 // ListSnapshots is an API handler listing available snapshots on the node.
@@ -67,8 +74,17 @@ func (s *SnapshotHandler) ListSnapshots(c *gin.Context) {
 	c.JSON(http.StatusOK, infos)
 }
 
-// DownloadBestSnapshot selects the best full snapshot and sends it to the client.
+// DownloadBestSnapshot selects the best full snapshot and redirects the client to it.
 func (s *SnapshotHandler) DownloadBestSnapshot(c *gin.Context) {
+	s.redirectBestSnapshot(c, true)
+}
+
+// DownloadBestIncrementalSnapshot selects the best incremental snapshot and redirects the client to it.
+func (s *SnapshotHandler) DownloadBestIncrementalSnapshot(c *gin.Context) {
+	s.redirectBestSnapshot(c, false)
+}
+
+func (s *SnapshotHandler) redirectBestSnapshot(c *gin.Context, full bool) {
 	files, err := ledger.ListSnapshotFiles(s.LedgerDir)
 	if err != nil {
 		s.Log.Error("Failed to list snapshot files", zap.Error(err))
@@ -76,8 +92,9 @@ func (s *SnapshotHandler) DownloadBestSnapshot(c *gin.Context) {
 		return
 	}
 	for _, file := range files {
-		if file.IsFull() {
-			s.serveSnapshot(c, file.FileName)
+		if file.IsFull() == full {
+			location := path.Join(path.Dir(c.Request.URL.Path), file.FileName)
+			c.Redirect(http.StatusSeeOther, location)
 			return
 		}
 	}

--- a/internal/sidecar/snapshot_test.go
+++ b/internal/sidecar/snapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.blockdaemon.com/solana/cluster-manager/internal/ledgertest"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -46,4 +47,47 @@ func TestHandler_ListSnapshots_Error(t *testing.T) {
 
 	res := testRequest(h, req)
 	assert.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestHandler_RedirectsBestSnapshots(t *testing.T) {
+	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+	root := ledgertest.NewFS(t)
+	root.AddFakeFile(t, "snapshot-100-"+hash+".tar.bz2")
+	root.AddFakeFile(t, "snapshot-200-"+hash+".tar.zst")
+	root.AddFakeFile(t, "incremental-snapshot-200-300-"+hash+".tar.zst")
+
+	h := &SnapshotHandler{
+		LedgerDir: root.GetLedgerDir(t),
+		Log:       zaptest.NewLogger(t),
+	}
+
+	req, err := http.NewRequest(http.MethodHead, "/snapshot.tar.bz2", nil)
+	require.NoError(t, err)
+	res := testRequest(h, req)
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, "/snapshot-200-"+hash+".tar.zst", res.Header().Get("Location"))
+
+	req, err = http.NewRequest(http.MethodHead, "/incremental-snapshot.tar.zst", nil)
+	require.NoError(t, err)
+	res = testRequest(h, req)
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, "/incremental-snapshot-200-300-"+hash+".tar.zst", res.Header().Get("Location"))
+}
+
+func TestHandler_DownloadRedirectTarget(t *testing.T) {
+	const name = "snapshot-100-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.bz2"
+	root := ledgertest.NewFS(t)
+	root.AddFakeFile(t, name)
+
+	h := &SnapshotHandler{
+		LedgerDir: root.GetLedgerDir(t),
+		Log:       zaptest.NewLogger(t),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/"+name, nil)
+	require.NoError(t, err)
+
+	res := testRequest(h, req)
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, "1", res.Header().Get("Content-Length"))
 }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -87,19 +87,14 @@ func (h *Handler) snapshotSource(c *gin.Context, entry *index.SnapshotEntry) typ
 	for i, file := range entry.Info.Files {
 		fileCopy := *file
 		if h.ProxySnapshotDownloads {
-			fileCopy.FileName = concreteSnapshotURL(c.Request, entry.Group, file.FileName)
+			fileCopy.DownloadURL = concreteSnapshotURL(c.Request, entry.Group, file.FileName)
 		}
 		info.Files[i] = &fileCopy
 	}
 
-	target := entry.Target
-	if h.ProxySnapshotDownloads {
-		target = trackerBaseURL(c.Request)
-	}
-
 	return types.SnapshotSource{
 		SnapshotInfo: info,
-		Target:       target,
+		Target:       entry.Target,
 		Group:        entry.Group,
 		UpdatedAt:    entry.UpdatedAt,
 	}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -338,6 +338,9 @@ func (h *Handler) serveCachedOrProxySnapshot(c *gin.Context, group string, file 
 	if h.cachedSnapshotMatches(name) {
 		return h.serveCachedSnapshot(c, name)
 	}
+	// prepareSnapshotCache removes stale cached archives before the refresh is
+	// fetched. If this request is interrupted or the upstream fetch fails, the
+	// cache remains empty until a later successful request repopulates it.
 	if err := h.prepareSnapshotCache(name); err != nil {
 		return err
 	}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -17,45 +17,87 @@ package tracker
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/gin-gonic/gin"
 	"go.blockdaemon.com/solana/cluster-manager/internal/index"
+	"go.blockdaemon.com/solana/cluster-manager/internal/ledger"
 	"go.blockdaemon.com/solana/cluster-manager/types"
 )
 
 // Handler implements the tracker API methods.
 type Handler struct {
-	DB             *index.DB
-	RPC            *rpc.Client
-	MaxSnapshotAge uint64
+	DB                     *index.DB
+	RPC                    *rpc.Client
+	MaxSnapshotAge         uint64
+	ProxySnapshotDownloads bool
+	HTTPClient             *http.Client
 }
 
 // NewHandler creates a new tracker API using the provided database.
 func NewHandler(db *index.DB, rpcURL string, maxSnapshotAge uint64) *Handler {
-	return &Handler{DB: db, RPC: rpc.New(rpcURL), MaxSnapshotAge: maxSnapshotAge}
+	return &Handler{
+		DB:             db,
+		RPC:            rpc.New(rpcURL),
+		MaxSnapshotAge: maxSnapshotAge,
+		HTTPClient:     http.DefaultClient,
+	}
 }
 
 // RegisterHandlers registers this API with Gin web framework.
 func (h *Handler) RegisterHandlers(group gin.IRoutes) {
 	group.GET("/snapshots", h.GetSnapshots)
 	group.GET("/best_snapshots", h.GetBestSnapshots)
+	group.HEAD("/snapshot.tar.bz2", h.RedirectBestSnapshot)
+	group.GET("/snapshot.tar.bz2", h.RedirectBestSnapshot)
+	group.HEAD("/snapshot.tar.zst", h.RedirectBestSnapshot)
+	group.GET("/snapshot.tar.zst", h.RedirectBestSnapshot)
+	group.HEAD("/incremental-snapshot.tar.bz2", h.RedirectBestIncrementalSnapshot)
+	group.GET("/incremental-snapshot.tar.bz2", h.RedirectBestIncrementalSnapshot)
+	group.HEAD("/incremental-snapshot.tar.zst", h.RedirectBestIncrementalSnapshot)
+	group.GET("/incremental-snapshot.tar.zst", h.RedirectBestIncrementalSnapshot)
 	group.GET("/health", h.Health)
+	group.HEAD("/:name", h.DownloadSnapshot)
+	group.GET("/:name", h.DownloadSnapshot)
 }
 
 func (h *Handler) createJson(c *gin.Context, entries []*index.SnapshotEntry) {
 	sources := make([]types.SnapshotSource, len(entries))
 	for i, entry := range entries {
-		sources[i] = types.SnapshotSource{
-			SnapshotInfo: *entry.Info,
-			Target:       entry.Target,
-			Group:        entry.Group,
-			UpdatedAt:    entry.UpdatedAt,
-		}
+		sources[i] = h.snapshotSource(c, entry)
 	}
 	c.JSON(http.StatusOK, sources)
+}
+
+func (h *Handler) snapshotSource(c *gin.Context, entry *index.SnapshotEntry) types.SnapshotSource {
+	info := *entry.Info
+	info.Files = make([]*types.SnapshotFile, len(entry.Info.Files))
+	for i, file := range entry.Info.Files {
+		fileCopy := *file
+		if h.ProxySnapshotDownloads {
+			fileCopy.FileName = concreteSnapshotURL(c.Request, entry.Group, file.FileName)
+		}
+		info.Files[i] = &fileCopy
+	}
+
+	target := entry.Target
+	if h.ProxySnapshotDownloads {
+		target = trackerBaseURL(c.Request)
+	}
+
+	return types.SnapshotSource{
+		SnapshotInfo: info,
+		Target:       target,
+		Group:        entry.Group,
+		UpdatedAt:    entry.UpdatedAt,
+	}
 }
 
 func (h *Handler) GetSnapshots(c *gin.Context) {
@@ -100,6 +142,201 @@ func (h *Handler) GetBestSnapshots(c *gin.Context) {
 	}
 	entries := h.DB.GetBestSnapshotsByGroup(query.Group, query.Max)
 	h.createJson(c, entries)
+}
+
+// RedirectBestSnapshot redirects to the best available full snapshot file.
+func (h *Handler) RedirectBestSnapshot(c *gin.Context) {
+	h.serveBestSnapshot(c, true)
+}
+
+// RedirectBestIncrementalSnapshot redirects to the best available incremental snapshot file.
+func (h *Handler) RedirectBestIncrementalSnapshot(c *gin.Context) {
+	h.serveBestSnapshot(c, false)
+}
+
+func (h *Handler) serveBestSnapshot(c *gin.Context, full bool) {
+	var query struct {
+		Group string `form:"group"`
+	}
+	if err := c.BindQuery(&query); err != nil {
+		return
+	}
+
+	var bestEntry *index.SnapshotEntry
+	var bestFile *types.SnapshotFile
+	for _, entry := range h.DB.GetBestSnapshotsByGroup(query.Group, -1) {
+		for _, file := range entry.Info.Files {
+			if file.IsFull() != full {
+				continue
+			}
+			if bestFile == nil || file.Compare(bestFile) > 0 {
+				bestEntry = entry
+				bestFile = file
+			}
+		}
+	}
+	if bestFile == nil {
+		c.String(http.StatusAccepted, "no snapshot available")
+		return
+	}
+
+	location := snapshotFileLocation(bestEntry.Target, bestFile.FileName)
+	if h.ProxySnapshotDownloads {
+		location = concreteSnapshotLocation(c.Request.URL.Path, bestFile.FileName, query.Group)
+	}
+	c.Redirect(http.StatusSeeOther, location)
+}
+
+// DownloadSnapshot proxies or redirects a concrete snapshot filename.
+func (h *Handler) DownloadSnapshot(c *gin.Context) {
+	name := c.Param("name")
+	if ledger.ParseSnapshotFileName(name) == nil {
+		c.String(http.StatusNotFound, "snapshot not found")
+		return
+	}
+
+	var query struct {
+		Group string `form:"group"`
+	}
+	if err := c.BindQuery(&query); err != nil {
+		return
+	}
+
+	entry, file := h.findSnapshotFile(query.Group, name)
+	if file == nil {
+		c.String(http.StatusNotFound, "snapshot not found")
+		return
+	}
+
+	location := snapshotFileLocation(entry.Target, file.FileName)
+	if !h.ProxySnapshotDownloads {
+		c.Redirect(http.StatusSeeOther, location)
+		return
+	}
+	if err := h.proxySnapshot(c, location); err != nil {
+		c.String(http.StatusBadGateway, "proxy snapshot download: %s", err)
+	}
+}
+
+func (h *Handler) findSnapshotFile(group string, name string) (*index.SnapshotEntry, *types.SnapshotFile) {
+	for _, entry := range h.DB.GetBestSnapshotsByGroup(group, -1) {
+		for _, file := range entry.Info.Files {
+			if snapshotFileBase(file.FileName) == name {
+				return entry, file
+			}
+		}
+	}
+	return nil, nil
+}
+
+func snapshotFileLocation(target string, fileName string) string {
+	fileURL, err := url.Parse(fileName)
+	if err == nil && fileURL.IsAbs() {
+		return fileURL.String()
+	}
+
+	targetURL, err := url.Parse(target)
+	if err != nil || !targetURL.IsAbs() {
+		return "/" + fileName
+	}
+	targetURL.Path = path.Join(targetURL.Path, "v1", fileName)
+	targetURL.RawPath = ""
+	targetURL.RawQuery = ""
+	targetURL.Fragment = ""
+	return targetURL.String()
+}
+
+func concreteSnapshotLocation(requestPath string, fileName string, group string) string {
+	location := path.Join(path.Dir(requestPath), snapshotFileBase(fileName))
+	if group != "" {
+		values := url.Values{}
+		values.Set("group", group)
+		location += "?" + values.Encode()
+	}
+	return location
+}
+
+func concreteSnapshotURL(req *http.Request, group string, fileName string) string {
+	return trackerBaseURL(req) + concreteSnapshotLocation(req.URL.Path, fileName, group)
+}
+
+func trackerBaseURL(req *http.Request) string {
+	scheme := req.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if req.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	host := req.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = req.Host
+	}
+	return scheme + "://" + host
+}
+
+func snapshotFileBase(fileName string) string {
+	fileURL, err := url.Parse(fileName)
+	if err == nil && fileURL.Path != "" {
+		return path.Base(fileURL.Path)
+	}
+	return filepath.Base(fileName)
+}
+
+func (h *Handler) proxySnapshot(c *gin.Context, location string) error {
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, location, nil)
+	if err != nil {
+		return err
+	}
+	copyProxyHeaders(req.Header, c.Request.Header)
+
+	client := h.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	copyProxyHeaders(c.Writer.Header(), res.Header)
+	c.Writer.WriteHeader(res.StatusCode)
+	if c.Request.Method == http.MethodHead {
+		return nil
+	}
+	if _, err := io.Copy(c.Writer, res.Body); err != nil {
+		return fmt.Errorf("copy response body: %w", err)
+	}
+	return nil
+}
+
+func copyProxyHeaders(dst http.Header, src http.Header) {
+	for key, values := range src {
+		if isHopByHopHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func isHopByHopHeader(key string) bool {
+	switch http.CanonicalHeaderKey(key) {
+	case "Connection",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"Te",
+		"Trailer",
+		"Transfer-Encoding",
+		"Upgrade":
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Handler) Health(c *gin.Context) {

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -21,8 +21,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/gagliardetto/solana-go/rpc"
@@ -38,7 +41,9 @@ type Handler struct {
 	RPC                    *rpc.Client
 	MaxSnapshotAge         uint64
 	ProxySnapshotDownloads bool
+	ProxySnapshotCacheDir  string
 	HTTPClient             *http.Client
+	cacheMu                sync.Mutex
 }
 
 // NewHandler creates a new tracker API using the provided database.
@@ -213,6 +218,12 @@ func (h *Handler) DownloadSnapshot(c *gin.Context) {
 		c.Redirect(http.StatusSeeOther, location)
 		return
 	}
+	if h.canUseSnapshotCache(query.Group, file) {
+		if err := h.serveCachedOrProxySnapshot(c, query.Group, file, location); err != nil {
+			c.String(http.StatusBadGateway, "proxy snapshot download: %s", err)
+		}
+		return
+	}
 	if err := h.proxySnapshot(c, location); err != nil {
 		c.String(http.StatusBadGateway, "proxy snapshot download: %s", err)
 	}
@@ -282,6 +293,143 @@ func snapshotFileBase(fileName string) string {
 		return path.Base(fileURL.Path)
 	}
 	return filepath.Base(fileName)
+}
+
+func (h *Handler) canUseSnapshotCache(group string, file *types.SnapshotFile) bool {
+	if h.ProxySnapshotCacheDir == "" {
+		return false
+	}
+	best := h.bestSnapshotFile(group, file.IsFull())
+	if best == nil {
+		return false
+	}
+	return snapshotFileBase(best.FileName) == snapshotFileBase(file.FileName)
+}
+
+func (h *Handler) bestSnapshotFile(group string, full bool) *types.SnapshotFile {
+	var best *types.SnapshotFile
+	for _, entry := range h.DB.GetBestSnapshotsByGroup(group, -1) {
+		for _, file := range entry.Info.Files {
+			if file.IsFull() != full {
+				continue
+			}
+			if best == nil || file.Compare(best) > 0 {
+				best = file
+			}
+		}
+	}
+	return best
+}
+
+func (h *Handler) serveCachedOrProxySnapshot(c *gin.Context, group string, file *types.SnapshotFile, location string) error {
+	name := snapshotFileBase(file.FileName)
+	if h.cachedSnapshotMatches(name) {
+		return h.serveCachedSnapshot(c, name)
+	}
+
+	if c.Request.Method == http.MethodHead || c.Request.Header.Get("Range") != "" || !h.cacheMu.TryLock() {
+		return h.proxySnapshot(c, location)
+	}
+	defer h.cacheMu.Unlock()
+
+	if !h.canUseSnapshotCache(group, file) {
+		return h.proxySnapshot(c, location)
+	}
+	if h.cachedSnapshotMatches(name) {
+		return h.serveCachedSnapshot(c, name)
+	}
+	if err := h.prepareSnapshotCache(name); err != nil {
+		return err
+	}
+	return h.proxyAndCacheSnapshot(c, location, name)
+}
+
+func (h *Handler) cachedSnapshotMatches(name string) bool {
+	_, err := os.Stat(filepath.Join(h.ProxySnapshotCacheDir, name))
+	return err == nil
+}
+
+func (h *Handler) serveCachedSnapshot(c *gin.Context, name string) error {
+	filePath := filepath.Join(h.ProxySnapshotCacheDir, name)
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	http.ServeContent(c.Writer, c.Request, name, stat.ModTime(), file)
+	return nil
+}
+
+func (h *Handler) prepareSnapshotCache(name string) error {
+	if err := os.MkdirAll(h.ProxySnapshotCacheDir, 0755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(h.ProxySnapshotCacheDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			continue
+		}
+		if ledger.ParseSnapshotFileName(entry.Name()) == nil && !strings.HasPrefix(entry.Name(), ".tmp-") {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(h.ProxySnapshotCacheDir, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *Handler) proxyAndCacheSnapshot(c *gin.Context, location string, name string) error {
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, location, nil)
+	if err != nil {
+		return err
+	}
+	copyProxyHeaders(req.Header, c.Request.Header)
+
+	client := h.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	tmpFile, err := os.CreateTemp(h.ProxySnapshotCacheDir, ".tmp-"+name+".")
+	if err != nil {
+		copyProxyHeaders(c.Writer.Header(), res.Header)
+		c.Writer.WriteHeader(res.StatusCode)
+		_, _ = io.Copy(c.Writer, res.Body)
+		return nil
+	}
+	tmpName := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpName)
+	}()
+
+	copyProxyHeaders(c.Writer.Header(), res.Header)
+	c.Writer.WriteHeader(res.StatusCode)
+
+	_, copyErr := io.Copy(c.Writer, io.TeeReader(res.Body, tmpFile))
+	closeErr := tmpFile.Close()
+	if copyErr != nil {
+		return fmt.Errorf("copy response body: %w", copyErr)
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil
+	}
+	return os.Rename(tmpName, filepath.Join(h.ProxySnapshotCacheDir, name))
 }
 
 func (h *Handler) proxySnapshot(c *gin.Context, location string) error {

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -1,0 +1,229 @@
+// Copyright 2022 Blockdaemon Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracker
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.blockdaemon.com/solana/cluster-manager/internal/index"
+	"go.blockdaemon.com/solana/cluster-manager/types"
+)
+
+func TestHandler_RedirectsBestSnapshots(t *testing.T) {
+	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+
+	db := index.NewDB()
+	db.UpsertSnapshots(
+		snapshotEntry("mainnet", "http://sidecar-1:13080", 200, 200, []*types.SnapshotFile{
+			snapshotFile("snapshot-200-"+hash+".tar.zst", 200, 0),
+		}),
+		snapshotEntry("mainnet", "http://sidecar-2:13080", 300, 200, []*types.SnapshotFile{
+			snapshotFile("incremental-snapshot-200-300-"+hash+".tar.zst", 300, 200),
+			snapshotFile("snapshot-200-"+hash+".tar.zst", 200, 0),
+		}),
+		snapshotEntry("devnet", "http://sidecar-3:13080", 400, 400, []*types.SnapshotFile{
+			snapshotFile("snapshot-400-"+hash+".tar.zst", 400, 0),
+		}),
+	)
+
+	router := newTrackerRouter(db)
+
+	req, err := http.NewRequest(http.MethodHead, "/v1/snapshot.tar.bz2?group=mainnet", nil)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, "http://sidecar-2:13080/v1/snapshot-200-"+hash+".tar.zst", res.Header().Get("Location"))
+
+	req, err = http.NewRequest(http.MethodHead, "/v1/incremental-snapshot.tar.zst?group=mainnet", nil)
+	require.NoError(t, err)
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, "http://sidecar-2:13080/v1/incremental-snapshot-200-300-"+hash+".tar.zst", res.Header().Get("Location"))
+}
+
+func TestHandler_RedirectPreservesHTTPFileLocations(t *testing.T) {
+	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+	const fileURL = "https://snapshots.example.com/snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"
+
+	db := index.NewDB()
+	db.UpsertSnapshots(snapshotEntry("mainnet", "https://snapshots.example.com", 500, 500, []*types.SnapshotFile{
+		snapshotFile(fileURL, 500, 0),
+	}))
+
+	req, err := http.NewRequest(http.MethodHead, "/v1/snapshot.tar.zst?group=mainnet", nil)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	newTrackerRouter(db).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, fileURL, res.Header().Get("Location"))
+}
+
+func TestHandler_ProxiesSnapshotDownloads(t *testing.T) {
+	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+	const fileName = "/snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"
+	const body = "snapshot-data"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, fileName, r.URL.Path)
+		w.Header().Set("Content-Length", "13")
+		w.Header().Set("Content-Type", "application/zstd")
+		w.Header().Set("X-Upstream", "yes")
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	db := index.NewDB()
+	db.UpsertSnapshots(snapshotEntry("mainnet", upstream.URL, 500, 500, []*types.SnapshotFile{
+		snapshotFile(upstream.URL+fileName, 500, 0),
+	}))
+
+	handler := NewHandler(db, "http://localhost:8899", 1000)
+	handler.ProxySnapshotDownloads = true
+	handler.HTTPClient = upstream.Client()
+	router := newTrackerRouterWithHandler(handler)
+
+	req, err := http.NewRequest(http.MethodGet, "/v1/snapshot.tar.zst?group=mainnet", nil)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, "/v1"+fileName+"?group=mainnet", res.Header().Get("Location"))
+
+	req, err = http.NewRequest(http.MethodGet, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Empty(t, res.Header().Get("Location"))
+	assert.Equal(t, "application/zstd", res.Header().Get("Content-Type"))
+	assert.Equal(t, "yes", res.Header().Get("X-Upstream"))
+	assert.Equal(t, body, res.Body.String())
+
+	req, err = http.NewRequest(http.MethodHead, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, "13", res.Header().Get("Content-Length"))
+	assert.Equal(t, "application/zstd", res.Header().Get("Content-Type"))
+	assert.Equal(t, "yes", res.Header().Get("X-Upstream"))
+	assert.Empty(t, res.Body.String())
+}
+
+func TestHandler_ProxySnapshotDownloadsRewritesSnapshotAPIs(t *testing.T) {
+	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+
+	db := index.NewDB()
+	db.UpsertSnapshots(snapshotEntry("mainnet", "https://snapshots.example.com", 500, 500, []*types.SnapshotFile{
+		snapshotFile("https://snapshots.example.com/snapshot-500-"+hash+".tar.zst", 500, 0),
+	}))
+
+	handler := NewHandler(db, "http://localhost:8899", 1000)
+	handler.ProxySnapshotDownloads = true
+	router := newTrackerRouterWithHandler(handler)
+
+	for _, path := range []string{
+		"/v1/best_snapshots?group=mainnet&max=1",
+		"/v1/snapshots?group=mainnet",
+	} {
+		req, err := http.NewRequest(http.MethodGet, path, nil)
+		require.NoError(t, err)
+		req.Host = "tracker.example.com"
+		req.Header.Set("X-Forwarded-Proto", "https")
+
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusOK, res.Code)
+		var sources []types.SnapshotSource
+		require.NoError(t, json.Unmarshal(res.Body.Bytes(), &sources))
+		require.Len(t, sources, 1)
+		assert.Equal(t, "https://tracker.example.com", sources[0].Target)
+		require.Len(t, sources[0].Files, 1)
+		assert.Equal(t, "https://tracker.example.com/v1/snapshot-500-"+hash+".tar.zst?group=mainnet", sources[0].Files[0].FileName)
+	}
+}
+
+func TestHandler_RedirectsConcreteSnapshotWhenProxyDisabled(t *testing.T) {
+	const fileName = "/snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"
+
+	db := index.NewDB()
+	db.UpsertSnapshots(snapshotEntry("mainnet", "http://sidecar:13080", 500, 500, []*types.SnapshotFile{
+		snapshotFile("snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst", 500, 0),
+	}))
+
+	req, err := http.NewRequest(http.MethodHead, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	newTrackerRouter(db).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusSeeOther, res.Code)
+	assert.Equal(t, "http://sidecar:13080/v1"+fileName, res.Header().Get("Location"))
+}
+
+func newTrackerRouter(db *index.DB) http.Handler {
+	handler := NewHandler(db, "http://localhost:8899", 1000)
+	return newTrackerRouterWithHandler(handler)
+}
+
+func newTrackerRouterWithHandler(handler *Handler) http.Handler {
+	gin.SetMode(gin.ReleaseMode)
+	engine := gin.New()
+	handler.RegisterHandlers(engine.Group("/v1"))
+	return engine
+}
+
+func snapshotEntry(group string, target string, slot uint64, baseSlot uint64, files []*types.SnapshotFile) *index.SnapshotEntry {
+	return &index.SnapshotEntry{
+		SnapshotKey: index.NewSnapshotKey(group, target, slot, baseSlot),
+		Info: &types.SnapshotInfo{
+			Slot:      slot,
+			BaseSlot:  baseSlot,
+			Hash:      files[0].Hash,
+			Files:     files,
+			TotalSize: uint64(len(files)),
+		},
+		UpdatedAt: time.Now(),
+	}
+}
+
+func snapshotFile(name string, slot uint64, baseSlot uint64) *types.SnapshotFile {
+	return &types.SnapshotFile{
+		FileName: name,
+		Slot:     slot,
+		BaseSlot: baseSlot,
+		Hash:     solana.MustHashFromBase58("AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"),
+		Ext:      ".tar.zst",
+		Size:     1,
+	}
+}

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -143,12 +143,17 @@ func TestHandler_ProxiesSnapshotDownloads(t *testing.T) {
 	assert.Empty(t, res.Body.String())
 }
 
-func TestHandler_ProxySnapshotDownloadsRewritesSnapshotAPIs(t *testing.T) {
+func TestHandler_ProxySnapshotDownloadsRewritesDownloadURLOnly(t *testing.T) {
 	const hash = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr"
+	const target = "https://snapshots.example.com"
+	const fileName = "snapshot-500-" + hash + ".tar.zst"
+	const downloadURL = target + "/" + fileName
 
 	db := index.NewDB()
-	db.UpsertSnapshots(snapshotEntry("mainnet", "https://snapshots.example.com", 500, 500, []*types.SnapshotFile{
-		snapshotFile("https://snapshots.example.com/snapshot-500-"+hash+".tar.zst", 500, 0),
+	file := snapshotFile(fileName, 500, 0)
+	file.DownloadURL = downloadURL
+	db.UpsertSnapshots(snapshotEntry("mainnet", target, 500, 500, []*types.SnapshotFile{
+		file,
 	}))
 
 	handler := NewHandler(db, "http://localhost:8899", 1000)
@@ -171,9 +176,10 @@ func TestHandler_ProxySnapshotDownloadsRewritesSnapshotAPIs(t *testing.T) {
 		var sources []types.SnapshotSource
 		require.NoError(t, json.Unmarshal(res.Body.Bytes(), &sources))
 		require.Len(t, sources, 1)
-		assert.Equal(t, "https://tracker.example.com", sources[0].Target)
+		assert.Equal(t, target, sources[0].Target)
 		require.Len(t, sources[0].Files, 1)
-		assert.Equal(t, "https://tracker.example.com/v1/snapshot-500-"+hash+".tar.zst?group=mainnet", sources[0].Files[0].FileName)
+		assert.Equal(t, fileName, sources[0].Files[0].FileName)
+		assert.Equal(t, "https://tracker.example.com/v1/"+fileName+"?group=mainnet", sources[0].Files[0].DownloadURL)
 	}
 }
 

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -18,6 +18,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -189,6 +192,106 @@ func TestHandler_RedirectsConcreteSnapshotWhenProxyDisabled(t *testing.T) {
 
 	assert.Equal(t, http.StatusSeeOther, res.Code)
 	assert.Equal(t, "http://sidecar:13080/v1"+fileName, res.Header().Get("Location"))
+}
+
+func TestHandler_CachesLatestProxiedSnapshotDownload(t *testing.T) {
+	const fileName = "/snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"
+	const body = "snapshot-data"
+
+	var upstreamRequests int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamRequests, 1)
+		assert.Equal(t, fileName, r.URL.Path)
+		w.Header().Set("Content-Length", "13")
+		w.Header().Set("Content-Type", "application/zstd")
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	cacheDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "snapshot-1-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"), []byte("old"), 0o600))
+
+	db := index.NewDB()
+	db.UpsertSnapshots(snapshotEntry("mainnet", upstream.URL, 500, 500, []*types.SnapshotFile{
+		snapshotFile(upstream.URL+fileName, 500, 0),
+	}))
+
+	handler := NewHandler(db, "http://localhost:8899", 1000)
+	handler.ProxySnapshotDownloads = true
+	handler.ProxySnapshotCacheDir = cacheDir
+	handler.HTTPClient = upstream.Client()
+	router := newTrackerRouterWithHandler(handler)
+
+	req, err := http.NewRequest(http.MethodGet, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, body, res.Body.String())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamRequests))
+	assert.FileExists(t, filepath.Join(cacheDir, "snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"))
+	assert.NoFileExists(t, filepath.Join(cacheDir, "snapshot-1-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"))
+
+	req, err = http.NewRequest(http.MethodGet, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, body, res.Body.String())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamRequests))
+
+	req, err = http.NewRequest(http.MethodHead, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, "13", res.Header().Get("Content-Length"))
+	assert.Empty(t, res.Body.String())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamRequests))
+}
+
+func TestHandler_ProxiesWithoutCachingWhenCacheRefreshInProgress(t *testing.T) {
+	const fileName = "/snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"
+	const body = "snapshot-data"
+
+	var upstreamRequests int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamRequests, 1)
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	cacheDir := t.TempDir()
+	db := index.NewDB()
+	db.UpsertSnapshots(snapshotEntry("mainnet", upstream.URL, 500, 500, []*types.SnapshotFile{
+		snapshotFile(upstream.URL+fileName, 500, 0),
+	}))
+
+	handler := NewHandler(db, "http://localhost:8899", 1000)
+	handler.ProxySnapshotDownloads = true
+	handler.ProxySnapshotCacheDir = cacheDir
+	handler.HTTPClient = upstream.Client()
+	handler.cacheMu.Lock()
+	router := newTrackerRouterWithHandler(handler)
+
+	req, err := http.NewRequest(http.MethodGet, "/v1"+fileName+"?group=mainnet", nil)
+	require.NoError(t, err)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, body, res.Body.String())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamRequests))
+	assert.NoFileExists(t, filepath.Join(cacheDir, "snapshot-500-AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr.tar.zst"))
+	handler.cacheMu.Unlock()
 }
 
 func newTrackerRouter(db *index.DB) http.Handler {

--- a/types/config.go
+++ b/types/config.go
@@ -28,6 +28,7 @@ import (
 type Config struct {
 	ScrapeInterval         time.Duration  `json:"scrape_interval" yaml:"scrape_interval"`
 	ProxySnapshotDownloads bool           `json:"proxy_snapshot_downloads" yaml:"proxy_snapshot_downloads"`
+	ProxySnapshotCacheDir  string         `json:"proxy_snapshot_cache_dir" yaml:"proxy_snapshot_cache_dir"`
 	TargetGroups           []*TargetGroup `json:"target_groups" yaml:"target_groups"`
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -26,8 +26,9 @@ import (
 
 // Config describes the root-level config file.
 type Config struct {
-	ScrapeInterval time.Duration  `json:"scrape_interval" yaml:"scrape_interval"`
-	TargetGroups   []*TargetGroup `json:"target_groups" yaml:"target_groups"`
+	ScrapeInterval         time.Duration  `json:"scrape_interval" yaml:"scrape_interval"`
+	ProxySnapshotDownloads bool           `json:"proxy_snapshot_downloads" yaml:"proxy_snapshot_downloads"`
+	TargetGroups           []*TargetGroup `json:"target_groups" yaml:"target_groups"`
 }
 
 // LoadConfig reads the config object from the file system.

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -65,6 +65,7 @@ func TestLoadConfigProxySnapshotDownloads(t *testing.T) {
 	err := os.WriteFile(configFile, []byte(`
 scrape_interval: 15s
 proxy_snapshot_downloads: true
+proxy_snapshot_cache_dir: /var/cache/solana-snapshots
 target_groups:
   - group: mainnet
     http_targets:
@@ -77,4 +78,5 @@ target_groups:
 	require.NoError(t, err)
 
 	assert.True(t, actual.ProxySnapshotDownloads)
+	assert.Equal(t, "/var/cache/solana-snapshots", actual.ProxySnapshotCacheDir)
 }

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -59,3 +59,22 @@ target_groups:
 		Targets: []string{"https://api.mainnet.solana.com"},
 	}, actual.TargetGroups[0].HttpTargets)
 }
+
+func TestLoadConfigProxySnapshotDownloads(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yml")
+	err := os.WriteFile(configFile, []byte(`
+scrape_interval: 15s
+proxy_snapshot_downloads: true
+target_groups:
+  - group: mainnet
+    http_targets:
+      targets:
+        - https://api.mainnet.solana.com
+`), 0o600)
+	require.NoError(t, err)
+
+	actual, err := LoadConfig(configFile)
+	require.NoError(t, err)
+
+	assert.True(t, actual.ProxySnapshotDownloads)
+}


### PR DESCRIPTION
## Summary
- add sidecar-compatible snapshot redirect endpoints for full and incremental snapshots
- add tracker redirect endpoints and concrete snapshot routes
- add proxy_snapshot_downloads config to proxy concrete snapshot downloads through the tracker
- rewrite /v1/snapshots and /v1/best_snapshots file URLs to tracker-local concrete URLs when proxying is enabled
- add optional proxy_snapshot_cache_dir support to cache the latest proxied concrete snapshot archive locally with atomic promotion after successful fetch

## Cache behavior
- short-form endpoints always redirect and never proxy/cache directly
- concrete tracker snapshot URLs serve from cache when the cached archive matches the current best full or incremental snapshot
- stale cached snapshot archives are removed before refreshing the cache
- one request performs a cache refresh at a time; concurrent requests fall back to normal uncached proxy streaming
- HEAD requests serve cached size metadata when available or proxy upstream HEAD otherwise
- Range requests on a cache miss bypass cache population and proxy upstream directly

## Refresh failure behavior
- refresh downloads stream to a temporary file and are promoted into the cache only after a successful 200 OK response
- if the client disconnects, the upstream fetch fails, or upstream returns a non-200 response, the temporary file is removed and no archive is promoted
- because stale archives are removed before refresh, a failed refresh for a new latest snapshot can leave the cache empty
- the next successful concrete GET for the latest snapshot repopulates the cache

## Validation
- go test ./...
- go test ./internal/tracker
- go test -race ./internal/tracker
- live-tested tracker proxy downloads using test-http-target-config.yml semantics with proxy_snapshot_downloads enabled; confirmed short redirect and concrete paths start downloading snapshot bytes and HEAD returns Content-Length
